### PR TITLE
Fixed issue with verify step for nRF5340 light bulb

### DIFF
--- a/src/common/steps/5xFamilyVerify/Verify.tsx
+++ b/src/common/steps/5xFamilyVerify/Verify.tsx
@@ -48,11 +48,11 @@ export default ({ vComIndex, regex }: { vComIndex: number; regex: RegExp }) => {
                                         'Timed out or did not receive expected value'
                                     )
                                 );
-                            }, 3000)
+                            }, 5000)
                         );
                     })
                     .catch(e => dispatch(setError(describeError(e))));
-            }, 3000);
+            }, 5000);
         }
     }, [dispatch, response, error, device, vComIndex, regex]);
 


### PR DESCRIPTION
It turned out that default timeout for verifying the output logs from the device is too small in some scenarios.